### PR TITLE
fix: use pam system-auth service `login`

### DIFF
--- a/pam/pam.c
+++ b/pam/pam.c
@@ -47,7 +47,7 @@ int check_password(const char* user, const char* password) {
     };
     test_password = password;
 
-    retval = pam_start("go/pam", user, &conv, &pam_handle);
+    retval = pam_start("login", user, &conv, &pam_handle);
 
     if (retval == PAM_SUCCESS)
         retval = pam_authenticate(pam_handle, 0);


### PR DESCRIPTION
we should use the `login` service_name instead of a custom one
for reference: see man pam_start.

fixes #7  
